### PR TITLE
update asset config for CKAN 2.9 compatibility

### DIFF
--- a/ckanext/facetcollapse/fanstatic/webassets.yml
+++ b/ckanext/facetcollapse/fanstatic/webassets.yml
@@ -1,0 +1,8 @@
+facetcollapse_js:
+  filter: rjsmin
+  output: ckanext-facetcollapse/%(version)s_facetcollapse_js.js
+  extra:
+    preload:
+      - base/main
+  contents:
+    - facetcollapse.js

--- a/ckanext/facetcollapse/templates/facetcollapse/snippets/facetcollapse_asset.html
+++ b/ckanext/facetcollapse/templates/facetcollapse/snippets/facetcollapse_asset.html
@@ -1,0 +1,1 @@
+{% asset 'facetcollapse/facetcollapse_js' %}

--- a/ckanext/facetcollapse/templates/facetcollapse/snippets/facetcollapse_resource.html
+++ b/ckanext/facetcollapse/templates/facetcollapse/snippets/facetcollapse_resource.html
@@ -1,0 +1,1 @@
+{% resource 'facetcollapse/facetcollapse.js' %}

--- a/ckanext/facetcollapse/templates/package/search.html
+++ b/ckanext/facetcollapse/templates/package/search.html
@@ -10,6 +10,10 @@
   <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
 </div>
 
-  {% resource 'facetcollapse/facetcollapse.js' %}
+  {% if h.ckan_version().split('.')[1] | int >= 9 %}
+    {% include 'facetcollapse/snippets/facetcollapse_asset.html' %}
+  {% else %}
+    {% include 'facetcollapse/snippets/facetcollapse_resource.html' %}
+  {% endif %}
 
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.0.1',
+    version='0.0.2',
 
     description='''Enable collapsing of the facet list''',
     long_description=long_description,


### PR DESCRIPTION
This does actually seem to work on CKAN 2.9 with just `{% resource 'facetcollapse/facetcollapse.js' %}` but having read over https://github.com/ckan/ckan/wiki/Python-3-migration-guide-for-extensions#web-assets-js-and-css and https://docs.ckan.org/en/2.9/contributing/frontend/assets.html this seems to be the recommended way now. Checked on CKAN 2.9 with both python 2 and 3. No changes needed to the python code for python 3.